### PR TITLE
feat: add --tensor-type-rules parameter to model conversion

### DIFF
--- a/modules/convert_ui.py
+++ b/modules/convert_ui.py
@@ -75,6 +75,17 @@ with gr.Blocks() as convert_block:
                         value=QUANTS[0],
                         interactive=True
                     )
+                    with gr.Accordion(
+                        label="Weight type per tensor pattern",
+                        open=False
+                    ):
+                        tensor_type_rules = gr.Textbox(
+                            show_label=False,
+                            container=False,
+                            value="",
+                            placeholder="example: \"^vae\\.=f16,model\\.=q8_0\"",
+                            interactive=True
+                        )
 
             verbose = gr.Checkbox(label="Verbose")
 
@@ -97,7 +108,7 @@ with gr.Blocks() as convert_block:
     # Interactive Bindings
     convert_btn.click(
         convert,
-        inputs=[model, model_dir_txt, quant_type,
+        inputs=[model, model_dir_txt, quant_type, tensor_type_rules,
                 gguf_name, verbose],
         outputs=[result]
     )

--- a/modules/sdcpp.py
+++ b/modules/sdcpp.py
@@ -540,7 +540,7 @@ def upscale(params: dict) -> Generator:
     yield from runner.run()
 
 def convert(
-    in_orig_model: str, in_model_dir: str, in_quant_type: str,
+    in_orig_model: str, in_model_dir: str, in_quant_type: str, in_tensor_type_rules: str = None,
     in_gguf_name: str = None, in_verbose: bool = False
 ) -> str:
     """Synchronously runs the model conversion command."""
@@ -560,6 +560,8 @@ def convert(
         '-o', gguf_path,
         '--type', in_quant_type
     ]
+    if in_tensor_type_rules:
+        command.extend(['--tensor-type-rules', in_tensor_type_rules])
     if in_verbose:
         command.append('-v')
 


### PR DESCRIPTION
It's currently only supported for model conversion.

I tried to make the interface a bit tidier by removing the control label and container, so the accordion can act as both; but I'm not sure how it'd work in general (mobile, non-default themes, etc), so feel free to adjust it as you prefer.