### PR TITLE
Add --offload-to-cpu option

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -78,6 +78,7 @@ DEFAULT_SETTINGS = {
         ["vae", "default"],
         ["controlnet", "default"]
     ],
+    'def_offload_to_cpu': False,
     'def_flash_attn': False,
     'def_diffusion_fa': False,
     'def_diffusion_conv_direct': False,

--- a/modules/core/common/sd_common.py
+++ b/modules/core/common/sd_common.py
@@ -148,6 +148,7 @@ class CommonRunner():
             '--circular': self._get_param('in_circular_padding') == CIRCULAR_PADDING[1],
             '--circularx': self._get_param('in_circular_padding') == CIRCULAR_PADDING[2],
             '--circulary': self._get_param('in_circular_padding') == CIRCULAR_PADDING[3],
+            '--offload-to-cpu': self._get_param('in_offload_to_cpu'),
             '--fa': self._get_param('in_flash_attn'),
             '--diffusion-fa': self._get_param('in_diffusion_fa'),
             '--diffusion-conv-direct': self._get_param('in_diffusion_conv_direct'),

--- a/modules/interfaces/cli/upscale_tab.py
+++ b/modules/interfaces/cli/upscale_tab.py
@@ -105,6 +105,10 @@ with gr.Blocks() as upscale_block:
                     output = gr.Textbox(
                         label="Output Name (optional)", value=""
                     )
+                    offload_to_cpu = gr.Checkbox(
+                        label="Offload to CPU",
+                        value=config.get('def_offload_to_cpu')
+                    )
                     flash_attn = gr.Checkbox(
                         label="Flash Attention", value=config.get('def_flash_attn')
                     )
@@ -181,6 +185,7 @@ with gr.Blocks() as upscale_block:
         'in_upscl_rep': upscl_rep,
         'in_upscl_tile_size': upscl_tile_size,
         'in_output': output,
+        'in_offload_to_cpu': offload_to_cpu,
         'in_flash_attn': flash_attn,
         'in_diffusion_conv_direct': diffusion_conv_direct,
         'in_color': color,

--- a/modules/interfaces/common/options_tab.py
+++ b/modules/interfaces/common/options_tab.py
@@ -72,6 +72,7 @@ OPTION_KEY_MAP = {
     'in_max_vram': 'def_max_vram',
     'in_backend_table': 'def_backend_table',
     'in_params_backend_table': 'def_params_backend_table',
+    'in_offload_to_cpu': 'def_offload_to_cpu',
     'in_flash_attn': 'def_flash_attn',
     'in_diffusion_fa': 'def_diffusion_fa',
     'in_diffusion_conv_direct': 'def_diffusion_conv_direct',

--- a/modules/ui/performance.py
+++ b/modules/ui/performance.py
@@ -56,6 +56,10 @@ def create_performance_ui():
             )
 
         with gr.Group():
+            offload_to_cpu = gr.Checkbox(
+                label="Offload to CPU",
+                value=config.get('def_offload_to_cpu')
+            )
             flash_attn = gr.Checkbox(
                 label="Flash Attention",
                 value=config.get('def_flash_attn')
@@ -84,6 +88,7 @@ def create_performance_ui():
         'in_eager_load': eager_load,
         'in_backend_table': backend_table,
         'in_params_backend_table': params_backend_table,
+        'in_offload_to_cpu': offload_to_cpu,
         'in_flash_attn': flash_attn,
         'in_diffusion_fa': diffusion_fa,
         'in_diffusion_conv_direct': diffusion_conv_direct,


### PR DESCRIPTION
Simple addition of a checkbox control to expose the `--offload-to-cpu` argument in stable-diffusion.cpp. This allows the text encoder and checkpoint/unet model to be loaded into VRAM one at a time, preventing out of memory errors for low VRAM situations.