### PR TITLE
Fix output file naming in sdcpp_cli.py

### DIFF
--- a/modules/core/cli/sdcpp_cli.py
+++ b/modules/core/cli/sdcpp_cli.py
@@ -242,7 +242,7 @@ class CommandRunner(CommonRunner):
         else:
             base, ext = os.path.splitext(self.output_path)
             self.outputs = [self.output_path] + [
-                f"{base}_{i}{ext}" for i in range(2, batch_count + 1)
+                f"{base}_{i}{ext}" for i in range(batch_count)
             ]
 
     def build_command(self):


### PR DESCRIPTION
When batch count size is greater than two, the outputs does not display in the gallery or in the generation photo view.

With batch count 4, stable-diffusion.cpp saves:

image_0.png
image_1.png
image_2.png
image_3.png

But the WebUI expects:

image.png
image_2.png
image_3.png
image_4.png